### PR TITLE
chore: recommend npm-version-lens extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -19,7 +19,7 @@
     "msjsdiag.debugger-for-chrome",
     "naumovs.color-highlight",
     "paulmolluzzo.convert-css-in-js",
-    "pflannery.vscode-versionlens",
+    "legalfina.npm-version-lens",
     "quicktype.quicktype",
     "richie5um2.vscode-sort-json",
     "streetsidesoftware.code-spell-checker",


### PR DESCRIPTION
## Recommend npm-version-lens

This PR updates `.vscode/extensions.json` to recommend [**npm-version-lens**](https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens) in place of the following extension(s):

- `pflannery.vscode-versionlens`

### Why?

**npm-version-lens** provides:
- Color-coded version indicators directly in `package.json`
- One-click version updates via an inline dropdown
- Inlay hints showing the latest available version

It is actively maintained and lightweight.

Marketplace: https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens