### PR TITLE
Export acoustic grand piano soundfont subpath and fix piano key label CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/index.es.js",
       "require": "./dist/index.cjs.js"
+    },
+    "./dist/soundfonts/acoustic_grand_piano-mp3": {
+      "default": "./dist/soundfonts/acoustic_grand_piano-mp3.js"
     }
   },
   "private": false,

--- a/stories/assets/sampleStyles.css
+++ b/stories/assets/sampleStyles.css
@@ -409,10 +409,7 @@ body .response-curve-picker text.button-selected {
   .ReactPiano__NoteLabel--noteName.ReactPiano__NoteLabel--natural,
 .ReactPiano--showNoteNames
   .ReactPiano__Key--selected
-  .ReactPiano__NoteLabel--noteName.ReactPiano__NoteLabel--natural,
-.ReactPiano--showNoteNames
-  .ReactPiano__Key--middleC
-  .ReactPiano__NoteLabel--noteName {
+  .ReactPiano__NoteLabel--noteName.ReactPiano__NoteLabel--natural {
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- Add `./dist/soundfonts/acoustic_grand_piano-mp3` package export for deep imports from client apps
- Remove redundant middle-C CSS selector that duplicated natural-key label styling

## Test plan
- [ ] Storybook piano picker labels render correctly for natural keys
- [ ] Client can import soundfont subpath when wired to this version

Made with [Cursor](https://cursor.com)