### PR TITLE
Bump version to 4.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zds-pickers",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `package.json` version from 4.1.7 to 4.1.8

## Test plan
- [ ] Verify package version in published artifacts after release


Made with [Cursor](https://cursor.com)